### PR TITLE
refactor: use resource library.Duration() functions

### DIFF
--- a/cmd/vela-build-summary/plugin.go
+++ b/cmd/vela-build-summary/plugin.go
@@ -20,7 +20,7 @@ type Plugin struct {
 	Repo *Repo
 }
 
-// Exec formats and runs the commands for doing stuff.
+// Exec formats and runs the commands for creating a summary of the build.
 func (p *Plugin) Exec() error {
 	logrus.Debug("running plugin with provided configuration")
 

--- a/cmd/vela-build-summary/service.go
+++ b/cmd/vela-build-summary/service.go
@@ -89,8 +89,6 @@ func serviceRows(table *uitable.Table, logs *[]library.Log, services *[]library.
 		size := serviceSize(&s, logs)
 
 		// calculate duration based off the service timestamps
-		//
-		// nolint: gosec // ignore memory aliasing
 		duration := s.Duration()
 
 		// calculate rate based off service duration and size

--- a/cmd/vela-build-summary/service.go
+++ b/cmd/vela-build-summary/service.go
@@ -9,40 +9,13 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/gosuri/uitable"
 	"github.com/sirupsen/logrus"
 )
-
-// serviceDuration is a helper function to calculate the total duration
-// a service ran for in a more consumable, human readable format.
-func serviceDuration(s *library.Service) string {
-	logrus.Debugf("calculating duration of service %s for build summary table", s.GetName())
-
-	// capture finished unix timestamp from service
-	f := time.Unix(s.GetFinished(), 0)
-	// capture started unix timestamp from service
-	st := time.Unix(s.GetStarted(), 0)
-
-	// check if service is in a pending or running state
-	if strings.EqualFold(s.GetStatus(), constants.StatusPending) ||
-		strings.EqualFold(s.GetStatus(), constants.StatusRunning) {
-		// set a default value to display for the service
-		f = time.Unix(time.Now().UTC().Unix(), 0)
-	}
-
-	// get the duration by subtracting the service started
-	// timestamp from the service finished timestamp.
-	d := f.Sub(st)
-
-	// return duration in a human readable form
-	return d.String()
-}
 
 // serviceLines is a helper function to calculate the total lines of logs
 // a service produced by measuring the newlines (\n) in that log entry.
@@ -118,7 +91,7 @@ func serviceRows(table *uitable.Table, logs *[]library.Log, services *[]library.
 		// calculate duration based off the service timestamps
 		//
 		// nolint: gosec // ignore memory aliasing
-		duration := serviceDuration(&s)
+		duration := s.Duration()
 
 		// calculate rate based off service duration and size
 		rate := fmt.Sprintf("%d B/s", serviceRate(duration, size))

--- a/cmd/vela-build-summary/step.go
+++ b/cmd/vela-build-summary/step.go
@@ -89,8 +89,6 @@ func stepRows(table *uitable.Table, logs *[]library.Log, steps *[]library.Step, 
 		size := stepSize(&s, logs)
 
 		// calculate duration based off the step timestamps
-		//
-		// nolint: gosec // ignore memory aliasing
 		duration := s.Duration()
 
 		// calculate rate based off step duration and size

--- a/cmd/vela-build-summary/step.go
+++ b/cmd/vela-build-summary/step.go
@@ -9,40 +9,13 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/gosuri/uitable"
 	"github.com/sirupsen/logrus"
 )
-
-// stepDuration is a helper function to calculate the total duration
-// a step ran for in a more consumable, human readable format.
-func stepDuration(s *library.Step) string {
-	logrus.Debugf("calculating duration of step %s for build summary table", s.GetName())
-
-	// capture finished unix timestamp from step
-	f := time.Unix(s.GetFinished(), 0)
-	// capture started unix timestamp from step
-	st := time.Unix(s.GetStarted(), 0)
-
-	// check if step is in a pending or running state
-	if strings.EqualFold(s.GetStatus(), constants.StatusPending) ||
-		strings.EqualFold(s.GetStatus(), constants.StatusRunning) {
-		// set a default value to display for the step
-		f = time.Unix(time.Now().UTC().Unix(), 0)
-	}
-
-	// get the duration by subtracting the step started
-	// timestamp from the step finished timestamp.
-	d := f.Sub(st)
-
-	// return duration in a human readable form
-	return d.String()
-}
 
 // stepLines is a helper function to calculate the total lines of logs
 // a step produced by measuring the newlines (\n) in that log entry.
@@ -118,7 +91,7 @@ func stepRows(table *uitable.Table, logs *[]library.Log, steps *[]library.Step, 
 		// calculate duration based off the step timestamps
 		//
 		// nolint: gosec // ignore memory aliasing
-		duration := stepDuration(&s)
+		duration := s.Duration()
 
 		// calculate rate based off step duration and size
 		rate := fmt.Sprintf("%d B/s", stepRate(duration, size))


### PR DESCRIPTION
Based off of https://github.com/go-vela/types/pull/222 and https://github.com/go-vela/types/pull/227

Similar to https://github.com/go-vela/cli/pull/333

This change uses the `<resource>.Duration()` functions from the `github.com/go-vela/types/library` package:

* https://pkg.go.dev/github.com/go-vela/types/library#Build.Duration
* https://pkg.go.dev/github.com/go-vela/types/library#Service.Duration
* https://pkg.go.dev/github.com/go-vela/types/library#Step.Duration

Also included in this change is the removal of the `duration()` helper functions for each resource.