### PR TITLE
chore(actions): update publish action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,7 +33,7 @@ jobs:
         make build-static-ci
 
     - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: target/vela-build-summary
         cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         make build-static-ci
 
     - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: target/vela-build-summary
         cache: true


### PR DESCRIPTION
the github action we are using to publish images got an update, we see the following in the build output:
```
>> elgohr/Publish-Docker-Github-Action@master has been deprecated.
>> Please use elgohr/Publish-Docker-Github-Action@v4 for a blast in speed and security.
```
see https://github.com/elgohr/Publish-Docker-Github-Action/releases/tag/v4